### PR TITLE
Handle prompt fallback for node labels

### DIFF
--- a/src/graphEditorModule.js
+++ b/src/graphEditorModule.js
@@ -83,7 +83,11 @@ const GraphEditorModule = (() => {
 
     function requestNodeLabel(message, defaultValue) {
         if (typeof window !== 'undefined' && typeof window.prompt === 'function') {
-            return Promise.resolve(window.prompt(message, defaultValue))
+            try {
+                return Promise.resolve(window.prompt(message, defaultValue))
+            } catch (error) {
+                console.warn('GraphEditorModule: window.prompt 调用失败，使用自定义弹窗。', error)
+            }
         }
 
         return new Promise(resolve => {


### PR DESCRIPTION
## Summary
- wrap the `window.prompt` call so Electron's unsupported prompt error no longer breaks node creation
- fall back to the existing custom modal when the native prompt throws

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8f3e1e1c48320b078e11256b73a6e